### PR TITLE
Add theme-color meta for Android

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta content='is-ie10-dead' name='title' />
+    <meta name="theme-color" content="#E91E63">
     <title>IE10 💀countdown</title>
     <link href='https://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
     <meta content='width=460' name='viewport'>


### PR DESCRIPTION
Just make it look gorgeous on Android:

![Android browser look](https://cloud.githubusercontent.com/assets/1488378/11920274/601de6f2-a751-11e5-9133-56c98d285b06.png)

If the color is too pink, we can choose a lighter variant from [ColorHexa](http://www.colorhexa.com/e91e63).

PS.: This is my first real pull request, did I make anything wrong (e.g. should I have created a new branch for this)?
